### PR TITLE
feat: add settings and logout icons for simpler user account management in sidebar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import {
     getSitesCB,
 } from "./store/selectors";
 import { Suspense } from "./components/Suspense";
+import { GlobalSnackbar } from "./components/GlobalSnackbar";
 import { ROUTES, type RouteConfig } from "./routes";
 
 function App() {
@@ -52,6 +53,7 @@ function App() {
                 <Route path="/login" element={<LoginPresenter />} />
                 <Route path="/account" element={<AccountPresenter />} />
             </Routes>
+            <GlobalSnackbar />
         </div>
     );
 }

--- a/frontend/src/components/GlobalSnackbar.tsx
+++ b/frontend/src/components/GlobalSnackbar.tsx
@@ -1,0 +1,33 @@
+import Alert from "@mui/material/Alert";
+import Snackbar from "@mui/material/Snackbar";
+import { useAppDispatch, useAppSelector } from "../store/store";
+import { getSnackbarMessageCB, getSnackbarOpenCB, getSnackbarSeverityCB } from "../store/selectors";
+import { hideSnackbar } from "../store/snackbarSlice";
+
+export function GlobalSnackbar() {
+    const dispatch = useAppDispatch();
+    const isOpen = useAppSelector(getSnackbarOpenCB);
+    const message = useAppSelector(getSnackbarMessageCB);
+    const severity = useAppSelector(getSnackbarSeverityCB);
+
+    function handleCloseCB(_event?: React.SyntheticEvent | Event, reason?: string) {
+        if (reason === "clickaway") {
+            return;
+        }
+
+        dispatch(hideSnackbar());
+    }
+
+    return (
+        <Snackbar
+            open={isOpen}
+            autoHideDuration={3000}
+            onClose={handleCloseCB}
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        >
+            <Alert onClose={handleCloseCB} severity={severity} variant="filled">
+                {message}
+            </Alert>
+        </Snackbar>
+    );
+}

--- a/frontend/src/presenters/accountPresenter.tsx
+++ b/frontend/src/presenters/accountPresenter.tsx
@@ -25,18 +25,24 @@ export function AccountPresenter() {
             dispatch(showSnackbar({ message: "Logged out", severity: "success" }));
             navigate("/");
         } catch {
-            alert("Failed to log out");
+            dispatch(showSnackbar({ message: "Failed to log out", severity: "error" }));
         }
     }
 
     async function handleDeleteCB() {
         try {
             await deleteUserAccount();
+            dispatch(showSnackbar({ message: "Account deleted", severity: "success" }));
             navigate("/");
         } catch (error: unknown) {
             const hasErrorCode = error !== null && typeof error === "object" && "code" in error;
             if (hasErrorCode && error.code === "auth/requires-recent-login") {
-                alert("Please log in again before deleting your account.");
+                dispatch(
+                    showSnackbar({
+                        message: "Please log in again before deleting your account.",
+                        severity: "warning",
+                    })
+                );
                 try {
                     await logoutUser();
                     navigate("/login");
@@ -44,7 +50,12 @@ export function AccountPresenter() {
                     console.error("Failed to redirect to login.");
                 }
             } else {
-                alert("Failed to delete account. Please try again later.");
+                dispatch(
+                    showSnackbar({
+                        message: "Failed to delete account. Please try again later.",
+                        severity: "error",
+                    })
+                );
             }
         }
     }

--- a/frontend/src/presenters/accountPresenter.tsx
+++ b/frontend/src/presenters/accountPresenter.tsx
@@ -1,12 +1,14 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAppSelector } from "../store/store";
+import { useAppDispatch, useAppSelector } from "../store/store";
 import { getAuthUserCB, getAuthLoadingCB } from "../store/selectors";
 import { AccountView } from "../views/accountView";
 import { logoutUser, deleteUserAccount } from "../firebase/authActions";
 import { Suspense } from "../components/Suspense";
+import { showSnackbar } from "../store/snackbarSlice";
 
 export function AccountPresenter() {
+    const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const user = useAppSelector(getAuthUserCB);
     const loading = useAppSelector(getAuthLoadingCB);
@@ -20,6 +22,7 @@ export function AccountPresenter() {
     async function handleLogoutCB() {
         try {
             await logoutUser();
+            dispatch(showSnackbar({ message: "Logged out", severity: "success" }));
             navigate("/");
         } catch {
             alert("Failed to log out");

--- a/frontend/src/presenters/sidebarPresenter.tsx
+++ b/frontend/src/presenters/sidebarPresenter.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { SidebarView } from "../views/sidebarView";
 import { useAppSelector } from "../store/store";
 import { getAuthUserCB } from "../store/selectors";
+import { logoutUser } from "../firebase/authActions";
 
 export function SidebarPresenter() {
     const [isOpen, setIsOpen] = useState(false);
@@ -19,6 +20,15 @@ export function SidebarPresenter() {
         setIsOpen(false);
     }
 
+    async function handleLogoutCB() {
+        try {
+            await logoutUser();
+            navigate("/");
+        } catch {
+            alert("Failed to log out");
+        }
+    }
+
     return (
         <SidebarView
             isOpen={isOpen}
@@ -26,6 +36,7 @@ export function SidebarPresenter() {
             user={user}
             onToggleCB={toggleSidebarCB}
             onNavigateCB={navigateCB}
+            onLogoutCB={handleLogoutCB}
         />
     );
 }

--- a/frontend/src/presenters/sidebarPresenter.tsx
+++ b/frontend/src/presenters/sidebarPresenter.tsx
@@ -28,7 +28,7 @@ export function SidebarPresenter() {
             dispatch(showSnackbar({ message: "Logged out", severity: "success" }));
             navigate("/");
         } catch {
-            alert("Failed to log out");
+            dispatch(showSnackbar({ message: "Failed to log out", severity: "error" }));
         }
     }
 

--- a/frontend/src/presenters/sidebarPresenter.tsx
+++ b/frontend/src/presenters/sidebarPresenter.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { SidebarView } from "../views/sidebarView";
-import { useAppSelector } from "../store/store";
+import { useAppDispatch, useAppSelector } from "../store/store";
 import { getAuthUserCB } from "../store/selectors";
 import { logoutUser } from "../firebase/authActions";
+import { showSnackbar } from "../store/snackbarSlice";
 
 export function SidebarPresenter() {
     const [isOpen, setIsOpen] = useState(false);
+    const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const location = useLocation();
     const user = useAppSelector(getAuthUserCB);
@@ -23,6 +25,7 @@ export function SidebarPresenter() {
     async function handleLogoutCB() {
         try {
             await logoutUser();
+            dispatch(showSnackbar({ message: "Logged out", severity: "success" }));
             navigate("/");
         } catch {
             alert("Failed to log out");

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -113,6 +113,18 @@ function getSelectedCustomDateCB(state: RootState) {
     return state.departureUI.selectedCustomDate;
 }
 
+function getSnackbarOpenCB(state: RootState) {
+    return state.snackbar.open;
+}
+
+function getSnackbarMessageCB(state: RootState) {
+    return state.snackbar.message;
+}
+
+function getSnackbarSeverityCB(state: RootState) {
+    return state.snackbar.severity;
+}
+
 // use createSelector for computationally expensive selectors
 // to memoize results and avoid unnecessary recalculations
 const getSelectedDelayDatesCB = createSelector(
@@ -152,6 +164,9 @@ export {
     getSelectedDepartureCB,
     getSelectedDatePresetCB,
     getSelectedCustomDateCB,
+    getSnackbarOpenCB,
+    getSnackbarMessageCB,
+    getSnackbarSeverityCB,
     getSelectedDelayDates,
     getSelectedDelayDatesCB,
 };

--- a/frontend/src/store/snackbarSlice.ts
+++ b/frontend/src/store/snackbarSlice.ts
@@ -1,0 +1,37 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+export type SnackbarSeverity = "success" | "info" | "warning" | "error";
+
+type SnackbarPayload = {
+    message: string;
+    severity: SnackbarSeverity;
+};
+
+type SnackbarState = {
+    open: boolean;
+    message: string;
+    severity: SnackbarSeverity;
+};
+
+const initialState: SnackbarState = {
+    open: false,
+    message: "",
+    severity: "info",
+};
+
+export const snackbarSlice = createSlice({
+    name: "snackbar",
+    initialState,
+    reducers: {
+        showSnackbar: (state, action: { payload: SnackbarPayload }) => {
+            state.open = true;
+            state.message = action.payload.message;
+            state.severity = action.payload.severity;
+        },
+        hideSnackbar: (state) => {
+            state.open = false;
+        },
+    },
+});
+
+export const { showSnackbar, hideSnackbar } = snackbarSlice.actions;

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -15,6 +15,7 @@ import {
     departureUISlice,
 } from "./reducers";
 import { authSlice } from "./authSlice";
+import { snackbarSlice } from "./snackbarSlice";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchSelectedDepartureStopDelays } from "./actions";
 import { setSelectedDeparture, setSelectedDatePreset, setSelectedCustomDate } from "./reducers";
@@ -31,6 +32,7 @@ export const store = configureStore({
         routeDelays: routeDelaysSlice.reducer,
         aggregatedDates: aggregatedDatesSlice.reducer,
         departureUI: departureUISlice.reducer,
+        snackbar: snackbarSlice.reducer,
     },
     middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware().prepend(listenerMiddleware.middleware),

--- a/frontend/src/views/sidebarView.tsx
+++ b/frontend/src/views/sidebarView.tsx
@@ -2,6 +2,8 @@ import MenuIcon from "@mui/icons-material/Menu";
 import CloseIcon from "@mui/icons-material/Close";
 import PersonIcon from "@mui/icons-material/Person";
 import LoginIcon from "@mui/icons-material/Login";
+import LogoutIcon from "@mui/icons-material/Logout";
+import SettingsIcon from "@mui/icons-material/Settings";
 import IconButton from "@mui/material/IconButton";
 import { AuthUserState } from "../store/authSlice";
 import { ROUTES, type RouteConfig } from "../routes";
@@ -14,6 +16,7 @@ type SidebarViewProps = {
     user: AuthUserState | null;
     onToggleCB: () => void;
     onNavigateCB: (path: string) => void;
+    onLogoutCB: () => void;
 };
 
 export function SidebarView({
@@ -22,6 +25,7 @@ export function SidebarView({
     user,
     onToggleCB,
     onNavigateCB,
+    onLogoutCB,
 }: SidebarViewProps) {
     function isActiveCB(path: string): boolean {
         if (path === "/") {
@@ -50,6 +54,37 @@ export function SidebarView({
         );
     }
 
+    function renderUserItem(user: AuthUserState) {
+        return (
+            <li>
+                <div className="flex items-center gap-2 rounded-md px-3 py-2.5 text-slate-700">
+                    {user.photoURL ? (
+                        <img
+                            src={user.photoURL}
+                            alt="avatar"
+                            className="h-8 w-8 rounded-full object-cover"
+                        />
+                    ) : (
+                        <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200">
+                            <PersonIcon fontSize="small" />
+                        </div>
+                    )}
+
+                    <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                        {user.displayName || user.email || "Account"}
+                    </span>
+
+                    <IconButton size="small" onClick={() => onNavigateCB("/account")}>
+                        <SettingsIcon fontSize="small" />
+                    </IconButton>
+                    <IconButton size="small" aria-label="Log out" onClick={onLogoutCB}>
+                        <LogoutIcon fontSize="small" />
+                    </IconButton>
+                </div>
+            </li>
+        );
+    }
+
     return (
         <>
             {/* Toggle button — always visible */}
@@ -72,19 +107,7 @@ export function SidebarView({
                     {ROUTES.map(renderNavItemCB)}
                     <li className="mt-8 border-t border-slate-200/20 pt-2" />
                     {user
-                        ? renderNavItemCB({
-                              label: user.displayName || user.email || "Account",
-                              path: "/account",
-                              icon: user.photoURL ? (
-                                  <img
-                                      src={user.photoURL}
-                                      alt="avatar"
-                                      className="h-5 w-5 rounded-full object-cover"
-                                  />
-                              ) : (
-                                  <PersonIcon fontSize="small" />
-                              ),
-                          })
+                        ? renderUserItem(user)
                         : renderNavItemCB({
                               label: "Log In",
                               path: "/login",


### PR DESCRIPTION
Closes https://github.com/mattiaskvist/forseningskartan/issues/66

Before (left) and after (right):

<img width="247" height="361" alt="image" src="https://github.com/user-attachments/assets/01f0b272-e1ac-4223-9464-76b6fe6f0aa7" />

<img width="245" height="361" alt="image" src="https://github.com/user-attachments/assets/081d7683-d534-4f1e-9050-36ddfc3f2c72" />

Also added a Snackbar component for notifications that we can reuse for other notifications. Currently it only shows messages for successful logout.