### PR TITLE
F/search history

### DIFF
--- a/frontend/src/components/SearchBar.test.tsx
+++ b/frontend/src/components/SearchBar.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SearchBar } from "./SearchBar";
+import { renderWithTheme } from "../test/renderWithTheme";
+
+// Simplified fixture
+const sites = [
+    { id: 1, gid: 1001, name: "Alpha", lat: 59.1, lon: 18.1 },
+    { id: 2, gid: 1002, name: "Beta", lat: 59.2, lon: 18.2 },
+    { id: 3, gid: 1003, name: "Gamma", lat: 59.3, lon: 18.3 },
+];
+
+describe("SearchBar", () => {
+    it("sorts recent searches first and displays history icons", async () => {
+        renderWithTheme(
+            <SearchBar 
+                sites={sites} 
+                selectedSite={null} 
+                handleSelectSiteCB={() => {}} 
+                recentSearchSiteIds={[3, 1]} 
+            />
+        );
+
+        // access the MUI Autocomplete input and open the options list
+        const input = screen.getByRole("combobox", { name: "Search stops" });
+        fireEvent.focus(input);
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+
+        const options = await screen.findAllByRole("option");
+        
+        expect(options.map((o) => o.textContent)).toEqual(["Gamma", "Alpha", "Beta"]);
+
+        // check that the history icon is shown for recent searches and not for non-recent ones
+        expect(within(options[0]).getByTestId("HistoryIcon")).toBeInTheDocument();
+        expect(within(options[1]).getByTestId("HistoryIcon")).toBeInTheDocument();
+        expect(within(options[2]).queryByTestId("HistoryIcon")).not.toBeInTheDocument();
+    });
+
+    it("bubbles recent matches to the top when filtering by input", async () => {
+        renderWithTheme(
+            <SearchBar 
+                sites={sites} 
+                selectedSite={null} 
+                handleSelectSiteCB={() => {}} 
+                recentSearchSiteIds={[2]} 
+            />
+        );
+
+        const input = screen.getByRole("combobox", { name: "Search stops" });
+        // 'a' matches all 3 sites, but Beta (id: 2) is a recent search
+        fireEvent.change(input, { target: { value: "a" } });
+        fireEvent.keyDown(input, { key: "ArrowDown" });
+
+        const options = await screen.findAllByRole("option");
+        
+        // beta should be first because it's a recent search
+        expect(options.map((o) => o.textContent)).toEqual(["Beta", "Alpha", "Gamma"]);
+        expect(within(options[0]).getByTestId("HistoryIcon")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/SearchBar.test.tsx
+++ b/frontend/src/components/SearchBar.test.tsx
@@ -13,11 +13,11 @@ const sites = [
 describe("SearchBar", () => {
     it("sorts recent searches first and displays history icons", async () => {
         renderWithTheme(
-            <SearchBar 
-                sites={sites} 
-                selectedSite={null} 
-                handleSelectSiteCB={() => {}} 
-                recentSearchSiteIds={[3, 1]} 
+            <SearchBar
+                sites={sites}
+                selectedSite={null}
+                handleSelectSiteCB={() => {}}
+                recentSearchSiteIds={[3, 1]}
             />
         );
 
@@ -27,7 +27,7 @@ describe("SearchBar", () => {
         fireEvent.keyDown(input, { key: "ArrowDown" });
 
         const options = await screen.findAllByRole("option");
-        
+
         expect(options.map((o) => o.textContent)).toEqual(["Gamma", "Alpha", "Beta"]);
 
         // check that the history icon is shown for recent searches and not for non-recent ones
@@ -38,11 +38,11 @@ describe("SearchBar", () => {
 
     it("bubbles recent matches to the top when filtering by input", async () => {
         renderWithTheme(
-            <SearchBar 
-                sites={sites} 
-                selectedSite={null} 
-                handleSelectSiteCB={() => {}} 
-                recentSearchSiteIds={[2]} 
+            <SearchBar
+                sites={sites}
+                selectedSite={null}
+                handleSelectSiteCB={() => {}}
+                recentSearchSiteIds={[2]}
             />
         );
 
@@ -52,7 +52,7 @@ describe("SearchBar", () => {
         fireEvent.keyDown(input, { key: "ArrowDown" });
 
         const options = await screen.findAllByRole("option");
-        
+
         // beta should be first because it's a recent search
         expect(options.map((o) => o.textContent)).toEqual(["Beta", "Alpha", "Gamma"]);
         expect(within(options[0]).getByTestId("HistoryIcon")).toBeInTheDocument();

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -4,6 +4,7 @@ import Autocomplete, {
 } from "@mui/material/Autocomplete";
 import { FilterOptionsState } from "@mui/material";
 import TextField from "@mui/material/TextField";
+import HistoryIcon from "@mui/icons-material/History";
 import { Site } from "../types/sl";
 
 const defaultFilterOptions = createFilterOptions<Site>({
@@ -46,24 +47,52 @@ export function SearchBar({
         props: React.HTMLAttributes<HTMLLIElement> & { key: React.Key },
         site: Site
     ) {
+        // check if the site is in the recent search site ids to show a history icon next to it
+        const isRecent = recentSearchSiteIds.includes(site.id);
+
         // customize how options are shown and avoid dupicate key errors
         return (
             <li {...props} key={site.id}>
+                {isRecent && (
+                    <HistoryIcon
+                        fontSize="small"
+                        color="action"
+                        sx={{ marginRight: 1, opacity: 0.7 }}
+                    />
+                )}
                 {site.name}
             </li>
         );
     }
 
+    // prioritize sites that are in the recent search list
+    function compareSitesByRecencyCB(siteA: Site, siteB: Site): number {
+        const aIsRecent = recentSearchSiteIds.includes(siteA.id);
+        const bIsRecent = recentSearchSiteIds.includes(siteB.id);
+        if (aIsRecent && !bIsRecent) return -1;
+        if (!aIsRecent && bIsRecent) return 1;
+        return 0;
+    }
+
     // this custom filter options function checks if the user has typed anything in the search bar,
-    // if not it shows the recent search site ids as suggestions,
+    // if not it shows the recent search site ids as suggestions at the top of the list,
     // otherwise it uses the default filter options function to show matching sites based on the user input
+    // but bubbles up matching recent search sites for a nice user experience
     function customFilterOptionsCB(options: Site[], state: FilterOptionsState<Site>) {
+        let defaultOptions = defaultFilterOptions(options, state);
+
         if (state.inputValue.trim() === "" && recentSearchSiteIds.length > 0) {
-            return recentSearchSiteIds
+            const recentSites = recentSearchSiteIds
                 .map((siteId) => options.find((site) => site.id === siteId))
                 .filter((site): site is Site => !!site);
+
+            const remainingSites = defaultOptions.filter((site) => !recentSites.includes(site)); // avoid duplicates
+            return [...recentSites, ...remainingSites].slice(0, defaultOptions.length); // keep the total number of options within the default limit
         }
-        return defaultFilterOptions(options, state);
+
+        // bubble up recent searches
+        defaultOptions.sort(compareSitesByRecencyCB);
+        return defaultOptions;
     }
 
     return (

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -2,10 +2,11 @@ import Autocomplete, {
     AutocompleteRenderInputParams,
     createFilterOptions,
 } from "@mui/material/Autocomplete";
+import { FilterOptionsState } from "@mui/material";
 import TextField from "@mui/material/TextField";
 import { Site } from "../types/sl";
 
-const filterOptions = createFilterOptions<Site>({
+const defaultFilterOptions = createFilterOptions<Site>({
     ignoreCase: true, // case insensitive matching
     trim: true, // trim whitespace
     limit: 100, // max number of suggestions to show, no limit is a bit laggy
@@ -15,9 +16,15 @@ type SearchBarProps = {
     sites: Site[];
     selectedSite: Site | null;
     handleSelectSiteCB: (siteId: number | null) => void;
+    recentSearchSiteIds?: number[];
 };
 
-export function SearchBar({ sites, selectedSite, handleSelectSiteCB }: SearchBarProps) {
+export function SearchBar({
+    sites,
+    selectedSite,
+    handleSelectSiteCB,
+    recentSearchSiteIds = [],
+}: SearchBarProps) {
     function getSiteNameCB(site: Site): string {
         return site.name;
     }
@@ -47,9 +54,21 @@ export function SearchBar({ sites, selectedSite, handleSelectSiteCB }: SearchBar
         );
     }
 
+    // this custom filter options function checks if the user has typed anything in the search bar,
+    // if not it shows the recent search site ids as suggestions,
+    // otherwise it uses the default filter options function to show matching sites based on the user input
+    function customFilterOptionsCB(options: Site[], state: FilterOptionsState<Site>) {
+        if (state.inputValue.trim() === "" && recentSearchSiteIds.length > 0) {
+            return recentSearchSiteIds
+                .map((siteId) => options.find((site) => site.id === siteId))
+                .filter((site): site is Site => !!site);
+        }
+        return defaultFilterOptions(options, state);
+    }
+
     return (
         <Autocomplete
-            filterOptions={filterOptions}
+            filterOptions={customFilterOptionsCB}
             getOptionLabel={getSiteNameCB}
             isOptionEqualToValue={isOptionEqualToValueCB}
             noOptionsText="No stops found"

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -79,7 +79,7 @@ export function SearchBar({
     // otherwise it uses the default filter options function to show matching sites based on the user input
     // but bubbles up matching recent search sites for a nice user experience
     function customFilterOptionsCB(options: Site[], state: FilterOptionsState<Site>) {
-        let defaultOptions = defaultFilterOptions(options, state);
+        const defaultOptions = defaultFilterOptions(options, state);
 
         if (state.inputValue.trim() === "" && recentSearchSiteIds.length > 0) {
             const recentSites = recentSearchSiteIds

--- a/frontend/src/firebase/userPreferences.test.ts
+++ b/frontend/src/firebase/userPreferences.test.ts
@@ -5,6 +5,7 @@ describe("sanitizeUserPreferences", () => {
     it("falls back to defaults for invalid input", () => {
         expect(sanitizeUserPreferences(null)).toEqual({
             favoriteSiteIds: [],
+            recentSearchSiteIds: [],
             appStyle: "Dark",
         });
     });
@@ -12,15 +13,18 @@ describe("sanitizeUserPreferences", () => {
     it("keeps only integer site ids and preserves order", () => {
         const sanitized = sanitizeUserPreferences({
             favoriteSiteIds: [4, "8", 9.5, 4, 7, {}, 7],
+            recentSearchSiteIds: [1, "2", 3.5, 1, 5, {}, 5],
             appStyle: "Dark",
         });
 
         expect(sanitized.favoriteSiteIds).toEqual([4, 4, 7, 7]);
+        expect(sanitized.recentSearchSiteIds).toEqual([1, 1, 5, 5]);
     });
 
     it("falls back to default app style for invalid value", () => {
         const sanitized = sanitizeUserPreferences({
             favoriteSiteIds: [1, 2],
+            recentSearchSiteIds: [1, 2],
             appStyle: "Neon",
         });
 
@@ -30,6 +34,7 @@ describe("sanitizeUserPreferences", () => {
     it("sets appStyle correctly", () => {
         const sanitized = sanitizeUserPreferences({
             favoriteSiteIds: [1, 2],
+            recentSearchSiteIds: [1, 2],
             appStyle: "Classic",
         });
 

--- a/frontend/src/firebase/userPreferences.ts
+++ b/frontend/src/firebase/userPreferences.ts
@@ -9,11 +9,11 @@ function isAppStyle(candidate: unknown): candidate is AppStyle {
     return typeof candidate === "string" && (appStyles as readonly string[]).includes(candidate);
 }
 
-export function sanitizeUserPreferences(candidate: unknown): UserPreferencesState {
-    function isIntegerSiteIdCB(siteId: unknown): siteId is number {
-        return Number.isInteger(siteId);
-    }
+function isIntegerSiteIdCB(siteId: unknown): siteId is number {
+    return Number.isInteger(siteId);
+}
 
+export function sanitizeUserPreferences(candidate: unknown): UserPreferencesState {
     if (candidate === null || typeof candidate !== "object") {
         return { ...defaultUserPreferencesState };
     }
@@ -21,6 +21,7 @@ export function sanitizeUserPreferences(candidate: unknown): UserPreferencesStat
     const parsedCandidate = candidate as {
         appStyle?: unknown;
         favoriteSiteIds?: unknown;
+        recentSearchSiteIds?: unknown;
     };
     const appStyle = isAppStyle(parsedCandidate.appStyle)
         ? parsedCandidate.appStyle
@@ -28,10 +29,15 @@ export function sanitizeUserPreferences(candidate: unknown): UserPreferencesStat
     const favoriteSiteIds = Array.isArray(parsedCandidate.favoriteSiteIds)
         ? parsedCandidate.favoriteSiteIds.filter(isIntegerSiteIdCB)
         : [];
-
+    const recentSearchSiteIds = Array.isArray(parsedCandidate.recentSearchSiteIds)
+        ? parsedCandidate.recentSearchSiteIds
+              .filter(isIntegerSiteIdCB) // keep only integers
+              .slice(0, 5) // keep only the 5 most recent
+        : [];
     return {
         appStyle,
         favoriteSiteIds,
+        recentSearchSiteIds,
     };
 }
 

--- a/frontend/src/presenters/mapPresenter.tsx
+++ b/frontend/src/presenters/mapPresenter.tsx
@@ -9,6 +9,7 @@ import {
     getDeparturesCB,
     getDeparturesLoadingCB,
     getFavoriteSiteIdsCB,
+    getRecentSearchSiteIdsCB,
     getAppStylePreferenceCB,
     getSelectedCustomDateCB,
     getSelectedDatePresetCB,
@@ -54,6 +55,7 @@ export function MapPresenter() {
     const isDepartureHistoricalDelayLoading = useAppSelector(getDepartureHistoricalDelayLoadingCB);
     const user = useAppSelector(getAuthUserCB);
     const favoriteSiteIds = useAppSelector(getFavoriteSiteIdsCB);
+    const recentSearchSiteIds = useAppSelector(getRecentSearchSiteIdsCB);
     const appStyle = useAppSelector(getAppStylePreferenceCB);
     const sites = useAppSelector(getSitesCB);
     const isSitesLoading = useAppSelector(getSitesLoadingCB);
@@ -154,6 +156,7 @@ export function MapPresenter() {
             sites={sites}
             selectedSite={selectedSite}
             handleSelectSiteCB={handleSelectSiteCB}
+            recentSearchSiteIds={recentSearchSiteIds}
             departureViewProps={departureViewProps}
             appStyle={appStyle}
             onAppStyleChange={handleAppStyleChangeACB}

--- a/frontend/src/presenters/mapPresenter.tsx
+++ b/frontend/src/presenters/mapPresenter.tsx
@@ -65,7 +65,7 @@ export function MapPresenter() {
     const handleSelectSiteCB = useCallback(
         (siteId: number | null) => {
             selectSiteCB({ dispatch, siteId });
-            if (siteId) {
+            if (siteId !== null) {
                 dispatch(recordRecentSearchSiteId(siteId));
             }
         },

--- a/frontend/src/presenters/mapPresenter.tsx
+++ b/frontend/src/presenters/mapPresenter.tsx
@@ -31,7 +31,11 @@ import { Departure } from "../types/sl";
 import { DatePreset } from "../types/departureDelay";
 import { AppStyle } from "../types/appStyle";
 import { DepartureViewProps } from "../views/departureView";
-import { setAppStylePreference, toggleFavoriteSiteId } from "../store/userPreferencesSlice";
+import {
+    recordRecentSearchSiteId,
+    setAppStylePreference,
+    toggleFavoriteSiteId,
+} from "../store/userPreferencesSlice";
 import { showSnackbar } from "../store/snackbarSlice";
 import { Suspense } from "../components/Suspense";
 import { getUpcomingDepartures } from "../utils/departures";
@@ -59,6 +63,9 @@ export function MapPresenter() {
     const handleSelectSiteCB = useCallback(
         (siteId: number | null) => {
             selectSiteCB({ dispatch, siteId });
+            if (siteId) {
+                dispatch(recordRecentSearchSiteId(siteId));
+            }
         },
         [dispatch]
     );

--- a/frontend/src/store/selectors.ts
+++ b/frontend/src/store/selectors.ts
@@ -155,6 +155,10 @@ function getAppStylePreferenceCB(state: RootState) {
     return state.userPreferences.appStyle;
 }
 
+function getRecentSearchSiteIdsCB(state: RootState) {
+    return state.userPreferences.recentSearchSiteIds ?? [];
+}
+
 // use createSelector for computationally expensive selectors
 // to memoize results and avoid unnecessary recalculations
 const getSelectedDelayDatesCB = createSelector(
@@ -234,6 +238,7 @@ export {
     getSnackbarSeverityCB,
     getFavoriteSiteIdsCB,
     getAppStylePreferenceCB,
+    getRecentSearchSiteIdsCB,
     getFavoriteSitesCB,
     getSelectedDelayDates,
     getSelectedDelayDatesCB,

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -45,6 +45,7 @@ import {
     setRouteDelaySelectedRouteKey,
 } from "./reducers";
 import { fetchUserPreferences, saveUserPreferences } from "../firebase/userPreferences";
+import { deleteCurrentUser, logoutCurrentUser } from "./authThunks";
 const listenerMiddleware = createListenerMiddleware();
 
 function mergeRecentSearchSiteIds(
@@ -126,16 +127,8 @@ listenerMiddleware.startListening({
     effect: async (action, listenerApi) => {
         const dispatch = listenerApi.dispatch as AppDispatch;
         const user = action.payload;
-        const previousState = listenerApi.getOriginalState() as RootState;
-
-        // if the user was not null before but is now, it means they logged out
-        // so we should clear recent searches from local storage.
-        const didLogout = previousState.auth.user !== null && user === null;
 
         if (!user) {
-            if (didLogout) {
-                dispatch(clearRecentSearchSiteIds());
-            }
             return;
         }
 
@@ -170,6 +163,14 @@ listenerMiddleware.startListening({
                 })
             );
         }
+    },
+});
+
+listenerMiddleware.startListening({
+    matcher: isAnyOf(logoutCurrentUser.fulfilled, deleteCurrentUser.fulfilled),
+    effect: (_, listenerApi) => {
+        const dispatch = listenerApi.dispatch as AppDispatch;
+        dispatch(clearRecentSearchSiteIds());
     },
 });
 

--- a/frontend/src/store/store.ts
+++ b/frontend/src/store/store.ts
@@ -20,9 +20,13 @@ import { authSlice, setUser } from "./authSlice";
 import { showSnackbar, snackbarSlice } from "./snackbarSlice";
 import {
     applyLoadedUserPreferences,
+    clearRecentSearchSiteIds,
+    clearStoredRecentSearchSiteIds,
     setAppStylePreference,
+    storeRecentSearchSiteIds,
     toggleFavoriteSiteId,
     userPreferencesSlice,
+    recordRecentSearchSiteId,
 } from "./userPreferencesSlice";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -42,6 +46,26 @@ import {
 } from "./reducers";
 import { fetchUserPreferences, saveUserPreferences } from "../firebase/userPreferences";
 const listenerMiddleware = createListenerMiddleware();
+
+function mergeRecentSearchSiteIds(
+    localRecentSearchSiteIds: number[] = [],
+    firebaseRecentSearchSiteIds: number[] = []
+): number[] {
+    const uniqueRecentSearchSiteIds = new Set<number>();
+
+    for (const siteId of [...localRecentSearchSiteIds, ...firebaseRecentSearchSiteIds]) {
+        if (!Number.isInteger(siteId) || uniqueRecentSearchSiteIds.has(siteId)) {
+            continue;
+        }
+
+        uniqueRecentSearchSiteIds.add(siteId);
+        if (uniqueRecentSearchSiteIds.size === 5) {
+            break;
+        }
+    }
+
+    return Array.from(uniqueRecentSearchSiteIds);
+}
 
 export const store = configureStore({
     reducer: {
@@ -102,21 +126,41 @@ listenerMiddleware.startListening({
     effect: async (action, listenerApi) => {
         const dispatch = listenerApi.dispatch as AppDispatch;
         const user = action.payload;
+        const previousState = listenerApi.getOriginalState() as RootState;
+
+        // if the user was not null before but is now, it means they logged out
+        // so we should clear recent searches from local storage.
+        const didLogout = previousState.auth.user !== null && user === null;
 
         if (!user) {
+            if (didLogout) {
+                dispatch(clearRecentSearchSiteIds());
+            }
             return;
         }
 
         try {
             const loadedPreferences = await fetchUserPreferences(user.uid);
+            const state = listenerApi.getState() as RootState;
+            const localPreferences = state.userPreferences;
 
             if (loadedPreferences) {
-                dispatch(applyLoadedUserPreferences(loadedPreferences));
+                const mergedPreferences = {
+                    ...loadedPreferences,
+                    recentSearchSiteIds: mergeRecentSearchSiteIds(
+                        localPreferences.recentSearchSiteIds,
+                        loadedPreferences.recentSearchSiteIds
+                    ),
+                };
+
+                dispatch(applyLoadedUserPreferences(mergedPreferences));
+                await saveUserPreferences(user.uid, mergedPreferences);
+                clearStoredRecentSearchSiteIds();
                 return;
             }
 
-            const state = listenerApi.getState() as RootState;
-            await saveUserPreferences(user.uid, state.userPreferences);
+            await saveUserPreferences(user.uid, localPreferences);
+            clearStoredRecentSearchSiteIds();
         } catch (error) {
             console.error("Failed to load user preferences:", error);
             dispatch(
@@ -129,13 +173,16 @@ listenerMiddleware.startListening({
     },
 });
 
+// user preferences
 listenerMiddleware.startListening({
-    matcher: isAnyOf(toggleFavoriteSiteId, setAppStylePreference),
+    matcher: isAnyOf(toggleFavoriteSiteId, setAppStylePreference, recordRecentSearchSiteId),
     effect: async (_, listenerApi) => {
         const state = listenerApi.getState() as RootState;
         const user = state.auth.user;
+        const recentSearchSiteIds = state.userPreferences.recentSearchSiteIds ?? [];
 
         if (!user) {
+            storeRecentSearchSiteIds(recentSearchSiteIds);
             return;
         }
 

--- a/frontend/src/store/userPreferencesSlice.test.ts
+++ b/frontend/src/store/userPreferencesSlice.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     applyLoadedUserPreferences,
+    recordRecentSearchSiteId,
     setAppStylePreference,
     toggleFavoriteSiteId,
     userPreferencesSlice,
@@ -16,6 +17,7 @@ describe("userPreferencesSlice", () => {
         // We expect a brand new user to have no favorites and a 'Dark' map style.
         expect(initialState).toEqual({
             favoriteSiteIds: [],
+            recentSearchSiteIds: [],
             appStyle: "Dark",
         });
     });
@@ -53,6 +55,7 @@ describe("userPreferencesSlice", () => {
             undefined,
             applyLoadedUserPreferences({
                 favoriteSiteIds: [2, 9],
+                recentSearchSiteIds: [1, 3, 5],
                 appStyle: "Classic",
             })
         );
@@ -60,7 +63,29 @@ describe("userPreferencesSlice", () => {
         // state should now exactly match the loaded data
         expect(hydratedState).toEqual({
             favoriteSiteIds: [2, 9],
+            recentSearchSiteIds: [1, 3, 5],
             appStyle: "Classic",
         });
+    });
+
+    // verify that recording recent searches works as expected
+    it("records recent search site IDs", () => {
+        let state = userPreferencesSlice.reducer(undefined, recordRecentSearchSiteId(10));
+        expect(state.recentSearchSiteIds).toEqual([10]);
+
+        // add more searches
+        state = userPreferencesSlice.reducer(state, recordRecentSearchSiteId(20));
+        state = userPreferencesSlice.reducer(state, recordRecentSearchSiteId(30));
+        expect(state.recentSearchSiteIds).toEqual([30, 20, 10]);
+
+        // re-add an existing search to move it to the front
+        state = userPreferencesSlice.reducer(state, recordRecentSearchSiteId(20));
+        expect(state.recentSearchSiteIds).toEqual([20, 30, 10]);
+
+        // add more searches to exceed the limit of 5
+        state = userPreferencesSlice.reducer(state, recordRecentSearchSiteId(40));
+        state = userPreferencesSlice.reducer(state, recordRecentSearchSiteId(50));
+        state = userPreferencesSlice.reducer(state, recordRecentSearchSiteId(60));
+        expect(state.recentSearchSiteIds).toEqual([60, 50, 40, 20, 30]); // should keep only the 5 most recent
     });
 });

--- a/frontend/src/store/userPreferencesSlice.ts
+++ b/frontend/src/store/userPreferencesSlice.ts
@@ -29,7 +29,7 @@ function storeAppStyle(style: AppStyle) {
  * - keeping only integer values
  * - removing duplicates while preserving first occurrence
  * - truncating to 5 entries
- * 
+ *
  * We do this to prevent corrupted data from localStorage causing issues.
  */
 function normalizeRecentSearchSiteIds(recentSearchSiteIds: unknown): number[] {

--- a/frontend/src/store/userPreferencesSlice.ts
+++ b/frontend/src/store/userPreferencesSlice.ts
@@ -2,6 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { AppStyle, appStyles } from "../types/appStyle";
 
 const APP_STYLE_STORAGE_KEY = "appStyle";
+const RECENT_SEARCH_STORAGE_KEY = "recentSearchSiteIds";
 
 function getStoredAppStyle(): AppStyle {
     try {
@@ -23,13 +24,38 @@ function storeAppStyle(style: AppStyle) {
     }
 }
 
+function getStoredRecentSearchSiteIds(): number[] {
+    try {
+        const stored = localStorage.getItem(RECENT_SEARCH_STORAGE_KEY);
+        if (stored) {
+            const parsed = JSON.parse(stored);
+            if (Array.isArray(parsed)) {
+                return parsed;
+            }
+        }
+    } catch {
+        // localStorage unavailable at module init in test environments
+    }
+    return [];
+}
+
+function storeRecentSearchSiteIds(siteIds: number[]) {
+    try {
+        localStorage.setItem(RECENT_SEARCH_STORAGE_KEY, JSON.stringify(siteIds));
+    } catch {
+        // ignore — test environments
+    }
+}
+
 export type UserPreferencesState = {
     favoriteSiteIds: number[];
+    recentSearchSiteIds?: number[];
     appStyle: AppStyle;
 };
 
 export const defaultUserPreferencesState: UserPreferencesState = {
     favoriteSiteIds: [],
+    recentSearchSiteIds: getStoredRecentSearchSiteIds(),
     appStyle: getStoredAppStyle(),
 };
 
@@ -43,6 +69,27 @@ function normalizeFavoriteSiteIds(favoriteSiteIds: number[]): number[] {
     }
 
     return Array.from(uniqueFavoriteSiteIds);
+}
+
+/** Normalizes the recentSearchSiteIds array by:
+ * - removing duplicates
+ * - keeping only integer values
+ * - truncating to 5 entries
+ */
+function normalizeRecentSearchSiteIds(recentSearchSiteIds: number[] | undefined): number[] {
+    if (!recentSearchSiteIds) {
+        return [];
+    }
+
+    const uniqueRecentSearchSiteIds = new Set<number>();
+
+    for (const siteId of recentSearchSiteIds) {
+        if (Number.isInteger(siteId)) {
+            uniqueRecentSearchSiteIds.add(siteId);
+        }
+    }
+
+    return Array.from(uniqueRecentSearchSiteIds).slice(0, 5); // keep max 5 recent searches
 }
 
 export const userPreferencesSlice = createSlice({
@@ -64,6 +111,22 @@ export const userPreferencesSlice = createSlice({
 
             state.favoriteSiteIds.push(siteId);
         },
+        /** removes existing occurrence of siteId if present.
+         * prepends siteId to the beginning of the recentSearchSiteIds array.
+         * truncates to 5 entries.
+         */
+        recordRecentSearchSiteId: (state, action: PayloadAction<number>) => {
+            const siteId = action.payload;
+
+            function isNotSelectedSiteIdCB(recentSiteId: number): boolean {
+                return recentSiteId !== siteId;
+            }
+
+            const filteredRecentSearchSiteIds =
+                state.recentSearchSiteIds?.filter(isNotSelectedSiteIdCB) ?? [];
+
+            state.recentSearchSiteIds = [siteId, ...filteredRecentSearchSiteIds].slice(0, 5); // keep max 5 recent searches
+        },
 
         setAppStylePreference: (state, action: PayloadAction<AppStyle>) => {
             state.appStyle = action.payload;
@@ -71,11 +134,19 @@ export const userPreferencesSlice = createSlice({
         },
         applyLoadedUserPreferences: (state, action: PayloadAction<UserPreferencesState>) => {
             state.favoriteSiteIds = normalizeFavoriteSiteIds(action.payload.favoriteSiteIds);
+            state.recentSearchSiteIds = normalizeRecentSearchSiteIds(
+                action.payload.recentSearchSiteIds
+            );
             state.appStyle = action.payload.appStyle;
             storeAppStyle(action.payload.appStyle);
+            storeRecentSearchSiteIds(state.recentSearchSiteIds);
         },
     },
 });
 
-export const { toggleFavoriteSiteId, setAppStylePreference, applyLoadedUserPreferences } =
-    userPreferencesSlice.actions;
+export const {
+    toggleFavoriteSiteId,
+    setAppStylePreference,
+    applyLoadedUserPreferences,
+    recordRecentSearchSiteId,
+} = userPreferencesSlice.actions;

--- a/frontend/src/store/userPreferencesSlice.ts
+++ b/frontend/src/store/userPreferencesSlice.ts
@@ -57,7 +57,7 @@ export function clearStoredRecentSearchSiteIds() {
 
 export type UserPreferencesState = {
     favoriteSiteIds: number[];
-    recentSearchSiteIds?: number[];
+    recentSearchSiteIds: number[];
     appStyle: AppStyle;
 };
 

--- a/frontend/src/store/userPreferencesSlice.ts
+++ b/frontend/src/store/userPreferencesSlice.ts
@@ -39,9 +39,17 @@ function getStoredRecentSearchSiteIds(): number[] {
     return [];
 }
 
-function storeRecentSearchSiteIds(siteIds: number[]) {
+export function storeRecentSearchSiteIds(siteIds: number[]) {
     try {
         localStorage.setItem(RECENT_SEARCH_STORAGE_KEY, JSON.stringify(siteIds));
+    } catch {
+        // ignore — test environments
+    }
+}
+
+export function clearStoredRecentSearchSiteIds() {
+    try {
+        localStorage.removeItem(RECENT_SEARCH_STORAGE_KEY);
     } catch {
         // ignore — test environments
     }
@@ -127,6 +135,10 @@ export const userPreferencesSlice = createSlice({
 
             state.recentSearchSiteIds = [siteId, ...filteredRecentSearchSiteIds].slice(0, 5); // keep max 5 recent searches
         },
+        clearRecentSearchSiteIds: (state) => {
+            state.recentSearchSiteIds = [];
+            clearStoredRecentSearchSiteIds();
+        },
 
         setAppStylePreference: (state, action: PayloadAction<AppStyle>) => {
             state.appStyle = action.payload;
@@ -139,7 +151,6 @@ export const userPreferencesSlice = createSlice({
             );
             state.appStyle = action.payload.appStyle;
             storeAppStyle(action.payload.appStyle);
-            storeRecentSearchSiteIds(state.recentSearchSiteIds);
         },
     },
 });
@@ -149,4 +160,5 @@ export const {
     setAppStylePreference,
     applyLoadedUserPreferences,
     recordRecentSearchSiteId,
+    clearRecentSearchSiteIds,
 } = userPreferencesSlice.actions;

--- a/frontend/src/store/userPreferencesSlice.ts
+++ b/frontend/src/store/userPreferencesSlice.ts
@@ -24,14 +24,41 @@ function storeAppStyle(style: AppStyle) {
     }
 }
 
+/** Normalizes recent search ids by:
+ * - requiring an array input
+ * - keeping only integer values
+ * - removing duplicates while preserving first occurrence
+ * - truncating to 5 entries
+ * 
+ * We do this to prevent corrupted data from localStorage causing issues.
+ */
+function normalizeRecentSearchSiteIds(recentSearchSiteIds: unknown): number[] {
+    if (!Array.isArray(recentSearchSiteIds)) {
+        return [];
+    }
+
+    const uniqueRecentSearchSiteIds = new Set<number>();
+
+    for (const siteId of recentSearchSiteIds) {
+        if (!Number.isInteger(siteId) || uniqueRecentSearchSiteIds.has(siteId)) {
+            continue;
+        }
+
+        uniqueRecentSearchSiteIds.add(siteId);
+        if (uniqueRecentSearchSiteIds.size === 5) {
+            break;
+        }
+    }
+
+    return Array.from(uniqueRecentSearchSiteIds);
+}
+
 function getStoredRecentSearchSiteIds(): number[] {
     try {
         const stored = localStorage.getItem(RECENT_SEARCH_STORAGE_KEY);
         if (stored) {
             const parsed = JSON.parse(stored);
-            if (Array.isArray(parsed)) {
-                return parsed;
-            }
+            return normalizeRecentSearchSiteIds(parsed);
         }
     } catch {
         // localStorage unavailable at module init in test environments
@@ -41,7 +68,10 @@ function getStoredRecentSearchSiteIds(): number[] {
 
 export function storeRecentSearchSiteIds(siteIds: number[]) {
     try {
-        localStorage.setItem(RECENT_SEARCH_STORAGE_KEY, JSON.stringify(siteIds));
+        localStorage.setItem(
+            RECENT_SEARCH_STORAGE_KEY,
+            JSON.stringify(normalizeRecentSearchSiteIds(siteIds))
+        );
     } catch {
         // ignore — test environments
     }
@@ -77,27 +107,6 @@ function normalizeFavoriteSiteIds(favoriteSiteIds: number[]): number[] {
     }
 
     return Array.from(uniqueFavoriteSiteIds);
-}
-
-/** Normalizes the recentSearchSiteIds array by:
- * - removing duplicates
- * - keeping only integer values
- * - truncating to 5 entries
- */
-function normalizeRecentSearchSiteIds(recentSearchSiteIds: number[] | undefined): number[] {
-    if (!recentSearchSiteIds) {
-        return [];
-    }
-
-    const uniqueRecentSearchSiteIds = new Set<number>();
-
-    for (const siteId of recentSearchSiteIds) {
-        if (Number.isInteger(siteId)) {
-            uniqueRecentSearchSiteIds.add(siteId);
-        }
-    }
-
-    return Array.from(uniqueRecentSearchSiteIds).slice(0, 5); // keep max 5 recent searches
 }
 
 export const userPreferencesSlice = createSlice({

--- a/frontend/src/views/mapSearchView.tsx
+++ b/frontend/src/views/mapSearchView.tsx
@@ -6,9 +6,15 @@ type MapSearchViewProps = {
     sites: Site[];
     selectedSite: Site | null;
     handleSelectSiteCB: (siteId: number | null) => void;
+    recentSearchSiteIds: number[];
 };
 
-export function MapSearchView({ sites, selectedSite, handleSelectSiteCB }: MapSearchViewProps) {
+export function MapSearchView({
+    sites,
+    selectedSite,
+    handleSelectSiteCB,
+    recentSearchSiteIds,
+}: MapSearchViewProps) {
     return (
         <Paper
             variant="outlined"
@@ -27,6 +33,7 @@ export function MapSearchView({ sites, selectedSite, handleSelectSiteCB }: MapSe
                 sites={sites}
                 selectedSite={selectedSite}
                 handleSelectSiteCB={handleSelectSiteCB}
+                recentSearchSiteIds={recentSearchSiteIds}
             />
         </Paper>
     );

--- a/frontend/src/views/mapView.tsx
+++ b/frontend/src/views/mapView.tsx
@@ -11,6 +11,7 @@ type MapViewProps = {
     sites: Site[];
     selectedSite: Site | null;
     handleSelectSiteCB: (siteId: number | null) => void;
+    recentSearchSiteIds: number[];
     departureViewProps: DepartureViewProps | null;
     appStyle: AppStyle;
     onAppStyleChange: (style: AppStyle) => void;
@@ -20,6 +21,7 @@ export function MapView({
     sites,
     selectedSite,
     handleSelectSiteCB,
+    recentSearchSiteIds,
     departureViewProps,
     appStyle,
     onAppStyleChange,
@@ -68,6 +70,7 @@ export function MapView({
                 sites={sites}
                 selectedSite={selectedSite}
                 handleSelectSiteCB={handleSelectSiteCB}
+                recentSearchSiteIds={recentSearchSiteIds}
             />
         </div>
     );


### PR DESCRIPTION
This pull request implements a recent search feature for sites, allowing users to see and select from their five most recently searched sites. The feature includes UI enhancements to display recent searches with a history icon, updates to the user preferences state and persistence logic, and comprehensive tests to ensure correct behavior. Additionally, recent search site IDs are synchronized between local storage and Firebase, and are properly cleared on logout. 

The most important changes are:

**Recent Search Feature Implementation:**
* Added a `recentSearchSiteIds` field to `UserPreferencesState`, including logic to record, normalize (deduplicate, limit to 5), and persist recent searches in both Redux state and local storage. [[1]](diffhunk://#diff-e9b65c7522b2a317338116bb0766c5003a5e150d4b423d98fdc0ecc24877b80aR27-R66) [[2]](diffhunk://#diff-e9b65c7522b2a317338116bb0766c5003a5e150d4b423d98fdc0ecc24877b80aR82-R102) [[3]](diffhunk://#diff-4ee108655952bafd0701a76e969abeb145c68787bc2c573d14caec65944837bdR20)
* Updated the `SearchBar` component to accept and display recent searches at the top of the suggestion list, including a history icon for recent items, and to prioritize/bubble up recent searches in the UI. [[1]](diffhunk://#diff-72931c05dcdad1b3c769f7076a3cc55e841d101dc1a57b18d001947df324fcb3R20-R28) [[2]](diffhunk://#diff-72931c05dcdad1b3c769f7076a3cc55e841d101dc1a57b18d001947df324fcb3R50-R100)

**Persistence and Synchronization:**
* On user login, merged local and Firebase `recentSearchSiteIds`, ensuring uniqueness and recency, then saved the merged preferences to Firebase and cleared local storage. [[1]](diffhunk://#diff-850873f68e06dcad7c36f851bef6b8cc33e6cb7c7aa9bc2f9a9b35e69cce021eR48-R70) [[2]](diffhunk://#diff-850873f68e06dcad7c36f851bef6b8cc33e6cb7c7aa9bc2f9a9b35e69cce021eR137-R156)
* On logout or account deletion, recent searches are cleared from both Redux state and local storage.

**Selectors and State Management:**
* Added selectors and Redux actions for `recentSearchSiteIds`, and ensured that recording a search updates both state and local storage (or Firebase if logged in). [[1]](diffhunk://#diff-544b83ffa61a6c772f0f3c7f645f1dcabb531803ea633197a38c971692dfd7aeR158-R161) [[2]](diffhunk://#diff-257f01eca69c9e7c3cfec9556a0cf6678d4315e9cea5890ddeb69e3163423f8bR12) [[3]](diffhunk://#diff-257f01eca69c9e7c3cfec9556a0cf6678d4315e9cea5890ddeb69e3163423f8bL34-R39) [[4]](diffhunk://#diff-257f01eca69c9e7c3cfec9556a0cf6678d4315e9cea5890ddeb69e3163423f8bR58) [[5]](diffhunk://#diff-257f01eca69c9e7c3cfec9556a0cf6678d4315e9cea5890ddeb69e3163423f8bR68-R70) [[6]](diffhunk://#diff-257f01eca69c9e7c3cfec9556a0cf6678d4315e9cea5890ddeb69e3163423f8bR159)

**Testing:**
* Added and updated tests for the new recent search functionality, including reducer logic, state hydration, and user preferences sanitization. [[1]](diffhunk://#diff-4ee108655952bafd0701a76e969abeb145c68787bc2c573d14caec65944837bdR58-R90) [[2]](diffhunk://#diff-4ee108655952bafd0701a76e969abeb145c68787bc2c573d14caec65944837bdR20) [[3]](diffhunk://#diff-123475af6c71dc2544bb43d99ba6b19b60384bdece24604664b1d1acc786e430R8-R27)

**User Preferences Sanitization:**
* Updated the `sanitizeUserPreferences` function to handle and validate `recentSearchSiteIds`, ensuring only integers are kept and the array is limited to 5 entries. [[1]](diffhunk://#diff-cb30a0c2d0754308b38d8bd64f011eae4c32efeed45d1b066b0a4d59683db635L12-R40) [[2]](diffhunk://#diff-123475af6c71dc2544bb43d99ba6b19b60384bdece24604664b1d1acc786e430R8-R27)

These changes together provide a robust, user-friendly recent search experience that persists across sessions and devices.

Closes #98 