### PR TITLE
fix(map): allow clicks to pass through invisible overlay wrapper

### DIFF
--- a/frontend/src/views/mapView.tsx
+++ b/frontend/src/views/mapView.tsx
@@ -39,7 +39,7 @@ export function MapView({
                     top: 16,
                     zIndex: 1000,
                     maxWidth: "calc(100vw - 2rem)",
-                    pointerEvents: "auto",
+                    pointerEvents: "none", // allow clicks to pass through invisible overlay wrapper
                 }}
             >
                 <Box


### PR DESCRIPTION
In the MapView component, we have floating UI elements (AppStyleSelector and MapDeparturesPanelView) positioned absolutely over the StopMap. Because these elements are grouped inside a Flexbox container, the browser draws an invisible rectangular bounding box around them to calculate the layout.

Previously, the outermost wrapper had pointerEvents: "auto" applied. This meant the entire bounding box, including the empty transparent space between and around the visible UI components, was actively intercepting mouse clicks and preventing them from reaching the map underneath.

I shifted the pointer event handling from the parent to the specific child elements:
	1.	Changed pointerEvents: "auto" to pointerEvents: "none" on the outer absolute <Box>. This forces the browser to ignore the invisible bounding box and lets clicks "fall through" to the map layer.
	2.	Relied on the existing "& > *": { pointerEvents: "auto" } rule on the inner Flexbox container. This re-enables pointer events only for the actual visible UI components, ensuring buttons and panels remain interactive.

Closes #113 