### PR TITLE
fix: leaderboard text overlap

### DIFF
--- a/frontend/src/views/routeDelayLeaderboardView.tsx
+++ b/frontend/src/views/routeDelayLeaderboardView.tsx
@@ -13,7 +13,8 @@ export function RouteDelayLeaderboardView({ leaderboardItems, t }: RouteDelayLea
 
         return (
             <li key={id} className="flex items-center justify-between text-sm">
-                <span className="flex items-center gap-3">
+                <span className="grid grid-cols-[70px_1fr] items-center">
+                    {/* 70px_1fr = 70px for rank and rest for route label */}
                     <Typography
                         component="span"
                         sx={{
@@ -75,8 +76,9 @@ export function RouteDelayLeaderboardView({ leaderboardItems, t }: RouteDelayLea
                             color: "text.secondary",
                         }}
                     >
-                        <span className="flex items-center gap-3">
-                            <span className="text-right">{t.rank}</span>
+                        <span className="grid grid-cols-[70px_1fr] items-center">
+                            {/* 70px_1fr = 70px for rank and rest for route label */}
+                            <span>{t.rank}</span>
                             <span>{t.route}</span>
                         </span>
                         <span className="flex tabular-nums">

--- a/frontend/src/views/routeDelayLeaderboardView.tsx
+++ b/frontend/src/views/routeDelayLeaderboardView.tsx
@@ -51,7 +51,7 @@ export function RouteDelayLeaderboardView({ leaderboardItems, t }: RouteDelayLea
                         color: "text.secondary",
                     }}
                 >
-                    No leaderboard data available.
+                    {t.noData}
                 </Typography>
             ) : (
                 <Box
@@ -76,7 +76,7 @@ export function RouteDelayLeaderboardView({ leaderboardItems, t }: RouteDelayLea
                         }}
                     >
                         <span className="flex items-center gap-3">
-                            <span className="w-6 text-right">{t.rank}</span>
+                            <span className="text-right">{t.rank}</span>
                             <span>{t.route}</span>
                         </span>
                         <span className="flex tabular-nums">


### PR DESCRIPTION
Closes https://github.com/mattiaskvist/forseningskartan/issues/159

<img width="1506" height="416" alt="image" src="https://github.com/user-attachments/assets/c6556cfc-2410-4a8a-afea-179e349e0974" />
