### PR TITLE
Highlight selected route stops on map

### DIFF
--- a/frontend/src/components/StopMap.tsx
+++ b/frontend/src/components/StopMap.tsx
@@ -35,13 +35,14 @@ export type MapCameraTarget = {
 const STOCKHOLM_CENTER: [number, number] = [59.3293, 18.0686];
 const STOCKHOLM_ZOOM = 13;
 const MAX_ZOOM = 19;
-const INCREASE_MARKER_SIZE_ZOOM = 15; // zoom level after which marker sizes start increasing to remain visible when zooming in
+// Marker circles become visually tiny at high zoom, so keep the base radius
+// until this zoom level and then grow it one pixel per zoom step.
+const INCREASE_MARKER_SIZE_ZOOM = 15;
 const BASE_MARKER_RADIUS = 4;
 const SELECTED_MARKER_RADIUS = 7;
 const ZOOM_CONTROL_POSITION: ControlPosition = "bottomleft";
 
 const ROUTE_MARKER_STYLE: CircleMarkerOptions = {
-    radius: BASE_MARKER_RADIUS,
     color: "#f59e0b", // bright orange
     fillColor: "#f59e0b",
     fillOpacity: 0.9,
@@ -67,7 +68,6 @@ const MAP_TILES: Record<AppStyle, { url: string; attribution: string }> = {
 };
 
 const SELECTED_MARKER_STYLE: CircleMarkerOptions = {
-    radius: SELECTED_MARKER_RADIUS,
     color: "#ef4444",
     fillColor: "#ef4444",
     fillOpacity: 0.95,
@@ -82,7 +82,6 @@ function getUnselectedMarkerStyle(appStyle: AppStyle): CircleMarkerOptions {
     };
     const color = UNSELECTED_MARKER_COLOR_BY_STYLE[appStyle];
     return {
-        radius: BASE_MARKER_RADIUS,
         color,
         fillColor: color,
         fillOpacity: 0.7,
@@ -94,17 +93,25 @@ function getSiteMarkerStyle(
     siteId: number,
     selectedSiteId: number | null,
     routeSiteIds: Set<number>,
-    appStyle: AppStyle
+    appStyle: AppStyle,
+    zoom: number
 ): CircleMarkerOptions {
+    // Radius depends on current Leaflet zoom, so every full style refresh must
+    // include it. Otherwise route/theme updates would reset zoom-scaled markers.
+    const radius =
+        siteId === selectedSiteId
+            ? getBaseMarkerRadius(zoom) + (SELECTED_MARKER_RADIUS - BASE_MARKER_RADIUS)
+            : getBaseMarkerRadius(zoom);
+
     if (siteId === selectedSiteId) {
-        return SELECTED_MARKER_STYLE;
+        return { ...SELECTED_MARKER_STYLE, radius };
     }
 
     if (routeSiteIds.has(siteId)) {
-        return ROUTE_MARKER_STYLE;
+        return { ...ROUTE_MARKER_STYLE, radius };
     }
 
-    return getUnselectedMarkerStyle(appStyle);
+    return { ...getUnselectedMarkerStyle(appStyle), radius };
 }
 
 function getBaseMarkerRadius(zoom: number) {
@@ -180,25 +187,27 @@ export function StopMap({
         mapRef.current = map;
         markersLayerRef.current = new LayerGroup().addTo(map);
 
-        // Update marker sizes on zoom to keep them visible and
-        // appropriately sized at different zoom levels
+        // Recompute full marker styles on zoom because radius is part of the
+        // style object and selected/route markers must preserve their colors.
         function updateMarkerSizesACB() {
             const zoom = map.getZoom();
-            const radius = getBaseMarkerRadius(zoom);
 
-            function setMarkerSizeCB(marker: CircleMarker, siteId: number) {
-                const isSelected = siteId === selectedSiteIdRef.current;
-
-                marker.setStyle({
-                    radius: isSelected
-                        ? radius + (SELECTED_MARKER_RADIUS - BASE_MARKER_RADIUS)
-                        : radius,
-                });
+            function setMarkerStyleCB(marker: CircleMarker, siteId: number) {
+                marker.setStyle(
+                    getSiteMarkerStyle(
+                        siteId,
+                        selectedSiteIdRef.current,
+                        selectedRouteSiteIdsRef.current,
+                        mapStyleRef.current,
+                        zoom
+                    )
+                );
             }
-            allMarkersBySiteIdRef.current.forEach(setMarkerSizeCB);
+            allMarkersBySiteIdRef.current.forEach(setMarkerStyleCB);
 
             // user position marker
             if (userMarkerRef.current) {
+                const radius = getBaseMarkerRadius(zoom);
                 userMarkerRef.current.setStyle({
                     radius: radius + (SELECTED_MARKER_RADIUS - BASE_MARKER_RADIUS),
                 });
@@ -258,7 +267,8 @@ export function StopMap({
                 site.id,
                 selectedSiteIdRef.current,
                 selectedRouteSiteIdsRef.current,
-                mapStyleRef.current
+                mapStyleRef.current,
+                mapRef.current?.getZoom() ?? STOCKHOLM_ZOOM
             )
         );
         marker.bindTooltip(site.name);
@@ -367,16 +377,19 @@ export function StopMap({
         nextVisibleSiteIds.forEach(showNewlyVisibleSiteCB);
     }, [filteredSites, createSiteMarker]);
 
-    // update marker styles when map style or selected route changes.
+    // Update marker styles when map style or selected route changes. Read the
+    // current zoom so this restyle keeps whatever zoom-scaled radius is active.
     useEffect(() => {
         selectedRouteSiteIdsRef.current = new Set(selectedRouteSiteIds);
+        const zoom = mapRef.current?.getZoom() ?? STOCKHOLM_ZOOM;
         function setMarkerStyleCB(marker: CircleMarker, siteId: number) {
             marker.setStyle(
                 getSiteMarkerStyle(
                     siteId,
                     selectedSiteIdRef.current,
                     selectedRouteSiteIdsRef.current,
-                    appStyle
+                    appStyle,
+                    zoom
                 )
             );
         }
@@ -390,6 +403,7 @@ export function StopMap({
         }
         const previousSelectedSiteId = selectedSiteIdRef.current;
         selectedSiteIdRef.current = selectedSiteId;
+        const zoom = mapRef.current.getZoom();
 
         if (selectedMarkerRef.current) {
             selectedMarkerRef.current.setStyle(
@@ -397,7 +411,8 @@ export function StopMap({
                     previousSelectedSiteId ?? -1,
                     selectedSiteId,
                     selectedRouteSiteIdsRef.current,
-                    mapStyleRef.current
+                    mapStyleRef.current,
+                    zoom
                 )
             );
         }
@@ -410,7 +425,8 @@ export function StopMap({
                         selectedSiteId,
                         selectedSiteId,
                         selectedRouteSiteIdsRef.current,
-                        mapStyleRef.current
+                        mapStyleRef.current,
+                        zoom
                     )
                 );
             }

--- a/frontend/src/components/StopMap.tsx
+++ b/frontend/src/components/StopMap.tsx
@@ -19,6 +19,7 @@ type StopMapProps = {
     onSiteMarkerClick: (siteId: number) => void;
     appStyle: AppStyle;
     userLocation: { lat: number; lon: number } | null;
+    selectedRouteSiteIds: number[];
     selectedSiteCameraTarget: MapCameraTarget | null;
     userLocationCameraTarget: MapCameraTarget | null;
 };
@@ -38,6 +39,14 @@ const INCREASE_MARKER_SIZE_ZOOM = 15; // zoom level after which marker sizes sta
 const BASE_MARKER_RADIUS = 4;
 const SELECTED_MARKER_RADIUS = 7;
 const ZOOM_CONTROL_POSITION: ControlPosition = "bottomleft";
+
+const ROUTE_MARKER_STYLE: CircleMarkerOptions = {
+    radius: BASE_MARKER_RADIUS,
+    color: "#f59e0b", // bright orange
+    fillColor: "#f59e0b",
+    fillOpacity: 0.9,
+    weight: 2, // thicker border
+};
 
 const MAP_TILES: Record<AppStyle, { url: string; attribution: string }> = {
     Dark: {
@@ -81,8 +90,21 @@ function getUnselectedMarkerStyle(appStyle: AppStyle): CircleMarkerOptions {
     };
 }
 
-function setMarkerSelectedStyle(marker: CircleMarker, isSelected: boolean, appStyle: AppStyle) {
-    marker.setStyle(isSelected ? SELECTED_MARKER_STYLE : getUnselectedMarkerStyle(appStyle));
+function getSiteMarkerStyle(
+    siteId: number,
+    selectedSiteId: number | null,
+    routeSiteIds: Set<number>,
+    appStyle: AppStyle
+): CircleMarkerOptions {
+    if (siteId === selectedSiteId) {
+        return SELECTED_MARKER_STYLE;
+    }
+
+    if (routeSiteIds.has(siteId)) {
+        return ROUTE_MARKER_STYLE;
+    }
+
+    return getUnselectedMarkerStyle(appStyle);
 }
 
 function getBaseMarkerRadius(zoom: number) {
@@ -100,6 +122,7 @@ export function StopMap({
     onSiteMarkerClick,
     appStyle,
     userLocation,
+    selectedRouteSiteIds,
     selectedSiteCameraTarget,
     userLocationCameraTarget,
 }: StopMapProps) {
@@ -113,6 +136,8 @@ export function StopMap({
     const visibleSiteIdsRef = useRef<Set<number>>(new Set());
     const selectedMarkerRef = useRef<CircleMarker | null>(null);
     const selectedSiteIdRef = useRef<number | null>(null);
+    // route highlighting restyles existing site markers. it should not create separate map points.
+    const selectedRouteSiteIdsRef = useRef<Set<number>>(new Set());
     const mapStyleRef = useRef(appStyle);
     const userMarkerRef = useRef<CircleMarker | null>(null);
     // Cached Leaflet handlers read this ref so they call the latest presenter callback.
@@ -196,6 +221,7 @@ export function StopMap({
             visibleSiteIds.clear();
             selectedMarkerRef.current = null;
             selectedSiteIdRef.current = null;
+            selectedRouteSiteIdsRef.current.clear();
             userMarkerRef.current = null;
             selectedSiteCameraRequestKeyRef.current = null;
             userLocationCameraRequestKeyRef.current = null;
@@ -228,7 +254,12 @@ export function StopMap({
         // Markers are cached, so selection policy stays outside this Leaflet adapter.
         const marker = new CircleMarker(
             [site.lat, site.lon],
-            getUnselectedMarkerStyle(mapStyleRef.current)
+            getSiteMarkerStyle(
+                site.id,
+                selectedSiteIdRef.current,
+                selectedRouteSiteIdsRef.current,
+                mapStyleRef.current
+            )
         );
         marker.bindTooltip(site.name);
 
@@ -336,29 +367,52 @@ export function StopMap({
         nextVisibleSiteIds.forEach(showNewlyVisibleSiteCB);
     }, [filteredSites, createSiteMarker]);
 
-    // Update marker styles when map style changes
+    // update marker styles when map style or selected route changes.
     useEffect(() => {
-        const selectedSiteId = selectedSiteIdRef.current;
+        selectedRouteSiteIdsRef.current = new Set(selectedRouteSiteIds);
         function setMarkerStyleCB(marker: CircleMarker, siteId: number) {
-            setMarkerSelectedStyle(marker, siteId === selectedSiteId, appStyle);
+            marker.setStyle(
+                getSiteMarkerStyle(
+                    siteId,
+                    selectedSiteIdRef.current,
+                    selectedRouteSiteIdsRef.current,
+                    appStyle
+                )
+            );
         }
         allMarkersBySiteIdRef.current.forEach(setMarkerStyleCB);
-    }, [appStyle]);
+    }, [appStyle, selectedRouteSiteIds]);
 
+    // update marker styles when selected site changes
     useEffect(() => {
         if (!mapRef.current) {
             return;
         }
+        const previousSelectedSiteId = selectedSiteIdRef.current;
         selectedSiteIdRef.current = selectedSiteId;
 
         if (selectedMarkerRef.current) {
-            setMarkerSelectedStyle(selectedMarkerRef.current, false, mapStyleRef.current);
+            selectedMarkerRef.current.setStyle(
+                getSiteMarkerStyle(
+                    previousSelectedSiteId ?? -1,
+                    selectedSiteId,
+                    selectedRouteSiteIdsRef.current,
+                    mapStyleRef.current
+                )
+            );
         }
 
         if (selectedSiteId !== null) {
             const selectedMarker = allMarkersBySiteIdRef.current.get(selectedSiteId) ?? null;
             if (selectedMarker) {
-                setMarkerSelectedStyle(selectedMarker, true, mapStyleRef.current);
+                selectedMarker.setStyle(
+                    getSiteMarkerStyle(
+                        selectedSiteId,
+                        selectedSiteId,
+                        selectedRouteSiteIdsRef.current,
+                        mapStyleRef.current
+                    )
+                );
             }
             selectedMarkerRef.current = selectedMarker;
             return;
@@ -367,6 +421,7 @@ export function StopMap({
         selectedMarkerRef.current = null;
     }, [selectedSiteId]);
 
+    // update map camera when selected site changes
     useEffect(() => {
         const map = mapRef.current;
         if (!selectedSiteCameraTarget) {

--- a/frontend/src/presenters/mapPresenter.tsx
+++ b/frontend/src/presenters/mapPresenter.tsx
@@ -44,7 +44,12 @@ import {
     setSelectedSiteId,
     setRouteDelaySelectedRouteKey,
 } from "../store/reducers";
-import { Departure, ModeWithOther, TransportationMode } from "../types/sl";
+import {
+    Departure,
+    ModeWithOther,
+    TransportationMode,
+    transportationModeToRouteType,
+} from "../types/sl";
 import { CustomDateRange, DatePreset } from "../types/departureDelay";
 import { AppStyle } from "../types/appStyle";
 import { DepartureViewProps } from "../views/departureView";
@@ -63,7 +68,7 @@ import {
     getSitesByTransportationMode,
     routeTypesToTransportationModes,
 } from "../utils/transportationMode";
-import { getSitesWithRoutes } from "../utils/site";
+import { getRouteSiteIds, getSitesWithRoutes } from "../utils/site";
 import { getDepartures, requestUserGeolocation } from "../store/actions";
 import { formatTime } from "../utils/time";
 import { translations } from "../utils/translations";
@@ -153,6 +158,34 @@ export function MapPresenter() {
         stopPointGidsBySiteId,
         stopPoints,
     ]);
+
+    // deriving route sites scans sites, stop points, and static route mappings.
+    // useMemo only recomputes that scan when those inputs change so StopMap does
+    // not restyle markers on unrelated presenter renders.
+    const selectedRouteSiteIds = useMemo(() => {
+        if (!selectedDeparture || !routesByStopPoint || !sites || !stopPoints) {
+            return [];
+        }
+
+        const routeShortName =
+            selectedDeparture.line.designation ?? selectedDeparture.line.id.toString();
+        const routeType = selectedDeparture.line.transport_mode
+            ? transportationModeToRouteType[selectedDeparture.line.transport_mode]
+            : null;
+
+        if (!routeType) {
+            return [];
+        }
+
+        return getRouteSiteIds(
+            sites,
+            stopPoints,
+            routesByStopPoint,
+            stopPointGidsBySiteId,
+            routeShortName,
+            routeType
+        );
+    }, [routesByStopPoint, selectedDeparture, sites, stopPointGidsBySiteId, stopPoints]);
 
     const handleSelectSiteCB = useCallback(
         (siteId: number | null) => {
@@ -358,6 +391,7 @@ export function MapPresenter() {
             appStyle={appStyle}
             onAppStyleChange={handleAppStyleChangeACB}
             userLocation={userLocation}
+            selectedRouteSiteIds={selectedRouteSiteIds}
             selectedSiteCameraTarget={selectedSiteCameraTarget}
             userLocationCameraTarget={userLocationCameraTarget}
             onRequestMapCenterOnUser={handleRequestMapCenterOnUserACB}

--- a/frontend/src/utils/site.test.ts
+++ b/frontend/src/utils/site.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { RoutesByStopPoint } from "../api/backend";
 import type { RouteMeta } from "../types/historicalDelay";
-import { getStopPointGidsForSite, StopPointGidsBySiteId } from "./site";
+import { getRouteSiteIds, getStopPointGidsForSite, StopPointGidsBySiteId } from "./site";
 import { Site, StopPoint } from "../types/sl";
 
 function makeRoute(type: RouteMeta["type"]): RouteMeta {
@@ -219,5 +219,31 @@ describe("getSitesWithRoutes", () => {
         );
 
         expect(result).toEqual([]);
+    });
+});
+
+describe("getRouteSiteIds", () => {
+    it("returns existing route site ids without duplicating a site", () => {
+        const sites: Site[] = [
+            { id: 1, name: "Route site", stop_areas: [10] } as Site,
+            { id: 2, name: "Other route site", stop_areas: [20] } as Site,
+            { id: 3, name: "Route site 2", stop_areas: [30] } as Site,
+        ];
+        const stopPoints: StopPoint[] = [
+            { id: 1, gid: "A", stop_area: { id: 10, name: "Area 10" } } as StopPoint,
+            { id: 2, gid: "A2", stop_area: { id: 10, name: "Area 10" } } as StopPoint,
+            { id: 3, gid: "B", stop_area: { id: 20, name: "Area 20" } } as StopPoint,
+            { id: 4, gid: "C", stop_area: { id: 30, name: "Area 30" } } as StopPoint,
+        ];
+        const routesByStopPoint: RoutesByStopPoint = {
+            A: [makeRoute("700")],
+            A2: [makeRoute("700")],
+            B: [makeRoute("401")],
+            C: [makeRoute("700")],
+        };
+
+        expect(getRouteSiteIds(sites, stopPoints, routesByStopPoint, {}, "1", "700")).toEqual([
+            1, 3,
+        ]);
     });
 });

--- a/frontend/src/utils/site.ts
+++ b/frontend/src/utils/site.ts
@@ -1,5 +1,6 @@
-import { RoutesByStopPoint } from "../api/backend";
-import { Site, StopPoint } from "../types/sl";
+import type { RoutesByStopPoint } from "../api/backend";
+import type { RouteType } from "../types/historicalDelay";
+import type { Site, StopPoint } from "../types/sl";
 
 export type StopPointGidsBySiteId = Record<number, string[]>;
 
@@ -77,4 +78,38 @@ export function getSitesWithRoutes(
     }
 
     return sites.filter(siteHasAnyRoutes);
+}
+
+// find the existing site markers that should be highlighted for a selected route.
+// The route data is keyed by stop point GID, while the map renders site markers,
+// so this bridges route-stop metadata back to site ids.
+export function getRouteSiteIds(
+    sites: Site[],
+    stopPoints: StopPoint[],
+    routesByStopPoint: RoutesByStopPoint,
+    stopPointGidsBySiteId: StopPointGidsBySiteId,
+    routeShortName: string,
+    routeType: RouteType
+): number[] {
+    const normalizedRouteShortName = routeShortName.trim();
+    if (normalizedRouteShortName === "") {
+        return [];
+    }
+
+    // identify stop points served by the selected route.
+    function stopPointHasSelectedRouteCB(stopPointGid: string): boolean {
+        return (routesByStopPoint[stopPointGid] ?? []).some(
+            (route) => route.shortName === normalizedRouteShortName && route.type === routeType
+        );
+    }
+
+    // mark a site as part of the route if any of its stop points match.
+    function siteHasSelectedRouteCB(site: Site): boolean {
+        return getStopPointGidsForSite(site, stopPoints, stopPointGidsBySiteId).some(
+            stopPointHasSelectedRouteCB
+        );
+    }
+
+    // return site ids, not stop point coordinates, so the map restyles existing markers.
+    return sites.filter(siteHasSelectedRouteCB).map((site) => site.id);
 }

--- a/frontend/src/views/mapView.test.tsx
+++ b/frontend/src/views/mapView.test.tsx
@@ -36,6 +36,7 @@ describe("MapView", () => {
             durationSeconds: 0.6,
             requestKey: 123,
         };
+        const selectedRouteSiteIds = [1, 3];
 
         renderWithTheme(
             <MapView
@@ -53,6 +54,7 @@ describe("MapView", () => {
                 appStyle="Dark"
                 onAppStyleChange={onAppStyleChange}
                 userLocation={null}
+                selectedRouteSiteIds={selectedRouteSiteIds}
                 selectedSiteCameraTarget={selectedSiteCameraTarget}
                 userLocationCameraTarget={userLocationCameraTarget}
                 onRequestMapCenterOnUser={vi.fn()}
@@ -77,6 +79,7 @@ describe("MapView", () => {
             expect.objectContaining({
                 selectedSiteId: 7,
                 onSiteMarkerClick,
+                selectedRouteSiteIds,
                 selectedSiteCameraTarget,
                 userLocationCameraTarget,
             })

--- a/frontend/src/views/mapView.tsx
+++ b/frontend/src/views/mapView.tsx
@@ -24,6 +24,7 @@ type MapViewProps = {
     appStyle: AppStyle;
     onAppStyleChange: (style: AppStyle) => void;
     userLocation: { lat: number; lon: number } | null;
+    selectedRouteSiteIds: number[];
     selectedSiteCameraTarget: MapCameraTarget | null;
     userLocationCameraTarget: MapCameraTarget | null;
     onRequestMapCenterOnUser: () => void;
@@ -57,6 +58,7 @@ export function MapView({
     appStyle,
     onAppStyleChange,
     userLocation,
+    selectedRouteSiteIds,
     selectedSiteCameraTarget,
     userLocationCameraTarget,
     onRequestMapCenterOnUser,
@@ -83,6 +85,7 @@ export function MapView({
                 onSiteMarkerClick={onSiteMarkerClick}
                 appStyle={appStyle}
                 userLocation={userLocation}
+                selectedRouteSiteIds={selectedRouteSiteIds}
                 selectedSiteCameraTarget={selectedSiteCameraTarget}
                 userLocationCameraTarget={userLocationCameraTarget}
             />


### PR DESCRIPTION
## Summary

- Highlight the existing map markers for stops served by the selected departure route.
- Keep route matching in the presenter/model utility layer and keep the Leaflet map as a passive renderer.
